### PR TITLE
This ensures correct agent packages are picked up.

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -130,6 +130,8 @@ class puppet::master (
       ensure  => $version,
       require => Package[puppetmaster-common],
     }
+    $dep_package_list = [ "puppet", "puppet-common" ]
+    ensure_resource(package, $dep_package_list, { 'ensure' => $version })
   }
   else
   {


### PR DESCRIPTION
Eventhough we have set hiera data to include the agent
version we still get this error when installing puppetmaster-common the puppetmaster on
ubuntu(debian)

```
Error: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install puppetmaster-common=3.4.3-1puppetlabs1' returned 100: Reading   package lists...
...<skipping>....
The following packages have unmet dependencies:
puppetmaster-common : Depends: puppet-common (= 3.4.3-1puppetlabs1) but 3.8.3-1puppetlabs1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

hiera data:

```
   nodes/puppet.mp.envato.test.yaml
   puppet::master::version: 3.4.3-1puppetlabs1
   puppet::agent::version: 3.4.3-1puppetlabs1
```
